### PR TITLE
chore: [CO-2843] define container for catalog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ ENV CATALOG_HOST=0.0.0.0
 ENV CATALOG_PORT=10000
 ENV CONSUL_URL=http://consul:8500
 ENV CONSUL_TOKEN_PATH=/etc/carbonio/catalog/service-discover/token
+RUN mkdir -p /etc/carbonio/catalog/service-discover/ \
+    && touch /etc/carbonio/catalog/service-discover/token
 
 ENTRYPOINT ["java", "-jar", "quarkus-app/quarkus-run.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM eclipse-temurin:17-jdk
+
+WORKDIR /app
+
+# Preserving the folder is important, else the app does not start
+COPY target/quarkus-app ./quarkus-app
+
+ENTRYPOINT ["java", "-jar", "quarkus-app/quarkus-run.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,9 @@ WORKDIR /app
 # Preserving the folder is important, else the app does not start
 COPY target/quarkus-app ./quarkus-app
 
+ENV CATALOG_HOST=0.0.0.0
+ENV CATALOG_PORT=10000
+ENV CONSUL_URL=http://consul:8500
+ENV CONSUL_TOKEN_PATH=/etc/carbonio/catalog/service-discover/token
+
 ENTRYPOINT ["java", "-jar", "quarkus-app/quarkus-run.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,10 @@ library(
     ])
 )
 
+boolean isBuildingTag() {
+    return env.TAG_NAME ? true : false
+}
+
 pipeline {
     agent {
         node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,6 +91,36 @@ pipeline {
                 }
             }
         }
+        stage('Publish containers') {
+            when {
+                expression {
+                    return isBuildingTag() || env.BRANCH_NAME == 'devel'
+                }
+            }
+            steps {
+                container('dind') {
+                    withDockerRegistry(credentialsId: 'private-registry', url: 'https://registry.dev.zextras.com') {
+                        script {
+                            Set<String> tagVersions = []
+                            if (isBuildingTag()) {
+                                tagVersions = [env.TAG_NAME, 'stable']
+                            } else {
+                                tagVersions = ['devel', 'latest']
+                            }
+                            dockerHelper.buildImage([
+                                    dockerfile: 'Dockerfile',
+                                    imageName : 'registry.dev.zextras.com/dev/carbonio-catalog',
+                                    imageTags : tagVersions,
+                                    ocLabels  : [
+                                            title          : 'Carbonio Catalog',
+                                            version        : tagVersions[0]
+                                    ]
+                            ])
+                        }
+                    }
+                }
+            }
+        }
 
         stage('Deploy') {
             when {

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -47,10 +47,8 @@ sha256sums=(
 package() {
   install -Ddm755 \
     "${pkgdir}/usr/share/carbonio/carbonio-catalog"
-
   cp -a "${srcdir}/quarkus-app" \
     "${pkgdir}/usr/share/carbonio/carbonio-catalog/"
-  test -e "${pkgdir}/usr/share/carbonio/carbonio-catalog/quarkus-app/quarkus-run.jar"
 
   install -Dm755 "${srcdir}/carbonio-catalog" \
     "${pkgdir}/usr/bin/carbonio-catalog"

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -47,8 +47,10 @@ sha256sums=(
 package() {
   install -Ddm755 \
     "${pkgdir}/usr/share/carbonio/carbonio-catalog"
+
   cp -a "${srcdir}/quarkus-app" \
     "${pkgdir}/usr/share/carbonio/carbonio-catalog/"
+  test -e "${pkgdir}/usr/share/carbonio/carbonio-catalog/quarkus-app/quarkus-run.jar"
 
   install -Dm755 "${srcdir}/carbonio-catalog" \
     "${pkgdir}/usr/bin/carbonio-catalog"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-quarkus.http.host=127.78.0.28
+quarkus.http.host=${CATALOG_HOST:127.78.0.28}
 %dev.quarkus.http.host=localhost
-quarkus.http.port=10000
+quarkus.http.port=${CATALOG_PORT:10000}
 quarkus.micrometer.export.prometheus.path=/metrics
 
 # logging
@@ -17,6 +17,6 @@ quarkus.log.file.path=/var/log/carbonio/catalog/application.log
 %test.quarkus.log.category."com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire".level=WARN
 
 # consul
-consul.url=http://localhost:8500
+consul.url=${CONSUL_URL:http://localhost:8500}
 consul.token.filepath=/etc/carbonio/catalog/service-discover/token
 %dev.consul.token.filepath=consul_token

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,5 +18,5 @@ quarkus.log.file.path=/var/log/carbonio/catalog/application.log
 
 # consul
 consul.url=${CONSUL_URL:http://localhost:8500}
-consul.token.filepath=/etc/carbonio/catalog/service-discover/token
+consul.token.filepath=${CONSUL_TOKEN_PATH:/etc/carbonio/catalog/service-discover/token}
 %dev.consul.token.filepath=consul_token


### PR DESCRIPTION
Adds container and support for environment variables, see: https://quarkus.io/guides/config-reference#with-environment-variables

Made sure that running the container with -e CATALOG_PORT=20000 actually starts the process on desired port.
Also defaults are applied correctly and by default binds to 0.0.0.0.

Container published to test CI