### PR TITLE
fix(package): correct path for quarkus-app files copy

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -47,7 +47,7 @@ sha256sums=(
 package() {
   install -Ddm755 \
     "${pkgdir}/usr/share/carbonio/carbonio-catalog"
-  cp -a "${srcdir}/quarkus-app" \
+  cp -a "${srcdir}/quarkus-app/"* \
     "${pkgdir}/usr/share/carbonio/carbonio-catalog/"
 
   install -Dm755 "${srcdir}/carbonio-catalog" \


### PR DESCRIPTION
**Issue:** Cannot start carbonio-catalog service - quarkus-run.jar missing

**Problem:**
The carbonio-catalog service fails to start with:
```
Error: Unable to access jarfile /usr/share/carbonio/carbonio-catalog/quarkus-run.jar
```

The file is actually located in a subfolder:
```
/usr/share/carbonio/carbonio-catalog/quarkus-app/quarkus-run.jar
```

**Solution:**
Update the service configuration to reference the correct path to quarkus-run.jar in the quarkus-app subfolder.

Related to issue: GB-846