### PR TITLE
ci: semantic release + maven ci friendly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@1.3.1',
+    identifier: 'jenkins-lib-common@1.3.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',
@@ -153,6 +153,13 @@ pipeline {
                 uploadStage(
                     packages: yapHelper.resolvePackageNames()
                 )
+            }
+        }
+        stage('Bump version') {
+            steps {
+                script {
+                    dt2_semanticRelease()
+                }
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,11 @@ SPDX-License-Identifier: AGPL-3.0-only
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.zextras.carbonio.catalog</groupId>
   <artifactId>carbonio-catalog-service</artifactId>
-  <version>0.0.4</version>
+  <version>${revision}</version>
   <name>carbonio catalog service</name>
 
   <properties>
+    <revision>0.0.4</revision>
     <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -97,6 +98,31 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-maven-plugin</artifactId>

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+  branches: ['main'],
+  tagFormat: "${version}",
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'conventionalcommits',
+        releaseRules: [
+          // enable release also for refactor and build commits
+          { type: 'refactor', release: 'patch' },
+          { type: 'build', release: 'patch' },
+          { type: 'ci', release: 'patch' },
+          { type: 'chore', 'scope': 'release', 'release': false},
+          { type: 'perf', release: 'patch' }
+        ]
+      }
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'conventionalcommits',
+        presetConfig: {
+          // see https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types
+          types: [
+            {
+              type: 'feat',
+              section: 'Features',
+              hidden: false
+            },
+            {
+              type: 'fix',
+              section: 'Bug Fixes',
+              hidden: false
+            },
+            {
+              type: 'refactor',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'perf',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'build',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'ci',
+              section: 'Other changes',
+              hidden: false
+            }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "sed -i 's|<revision>.*</revision>|<revision>${nextRelease.version}</revision>|' pom.xml && sed -i 's/^pkgver=.*/pkgver=\"${nextRelease.version}\"/' package/PKGBUILD"
+      }
+    ],
+    [
+      '@semantic-release/git',
+      {
+        assets: ['pom.xml', 'package/PKGBUILD'],
+        message: 'chore(release): ${nextRelease.version} [skip ci]'
+      }
+    ],
+    '@semantic-release/github'
+  ]
+};

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -8,7 +8,7 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
-  branches: ['main'],
+  branches: ['devel'],
   tagFormat: "${version}",
   plugins: [
     [


### PR DESCRIPTION
Maven ci friendly smoothens the version bump because there is only one <revision> key in the whole pom.xml, while there are many <version>