### PR TITLE
feat: replace shell-based systemd notification with native sd_notify via Java FFM

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -19,7 +19,6 @@ depends=(
   "pending-setups"
 )
 source=(
-  "${pkgname}"
   "${pkgname}-intentions.json"
   "${pkgname}-legacy.service"
   "${pkgname}-policies.json"
@@ -36,7 +35,6 @@ source=(
 )
 
 sha256sums=(
-  '599d10048be4ae408c498bba33b157015006d61916d4a051cfdbf31933f130cc'
   '5fed7682316886fcd053b545c42a25ff2fc9d5da949e3da97134e70e8ab25450'
   'b0d97d24c23f0fe3610c90c07e24cd022a9b83de5cc0adcd8568a522c652a673'
   '376c53798291548ef9968a60b4dbef6fdd9c255a6dac11adc6b1cfcc42c2b727'
@@ -46,7 +44,7 @@ sha256sums=(
   '2d25c035543096e4a2de4206a0a852ee3ce3855838c474661cde6ed628ef7513'
   'fa91665cf06ba93b13cab20c486eb8da6a2c594c11c23e638ea54a4b87f8c699'
   '5b14e0d88272e89f79a21e432a4dbb3b3032e31528507e4c3aacfc056f82dc1d'
-  '79d20c49b0463a802f264772a99f39862f87c30ba3509f27a9ab4ed11271e6aa'
+  '8eeebf5d6e010a30bf7ad1bfa57ffd3e2b5329c5b86420ae4c865f7068529a54'
   '70ca4a16079af600db5849c0bcb768c0ea96e05d772ee483df0beef44a700113'
   '24af59455eac8fd95bfc48536e913f62e7eae24d99458e0663585f1024a8599f'
   '74784b308b0881668f06293f9f4d8a45a76c9a4ec06f0d94e3a151c03b8524af'
@@ -57,9 +55,6 @@ _package() {
     "${pkgdir}/usr/share/carbonio/carbonio-catalog"
   cp -a "${srcdir}/quarkus-app/"* \
     "${pkgdir}/usr/share/carbonio/carbonio-catalog/"
-
-  install -Dm755 "${srcdir}/carbonio-catalog" \
-    "${pkgdir}/usr/bin/carbonio-catalog"
 
   install -Dm755 "${srcdir}/carbonio-catalog-setup" \
     "${pkgdir}/usr/bin/carbonio-catalog-setup"

--- a/package/carbonio-catalog
+++ b/package/carbonio-catalog
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-JAVA_HOME="/opt/zextras/common/lib/jvm/java"
-export JAVA_HOME
-/opt/zextras/common/bin/java \
-  -Xms1024m \
-  -jar /usr/share/carbonio/carbonio-catalog/quarkus-run.jar

--- a/package/carbonio-catalog.service
+++ b/package/carbonio-catalog.service
@@ -7,29 +7,13 @@ PartOf=carbonio-mta.target carbonio-proxy.target
 
 [Service]
 Type=notify
-NotifyAccess=all
-ExecStart=/bin/sh -c '\
-  /usr/bin/carbonio-catalog & \
-  APP_PID=$$! ; \
-  CATALOG_READY_PORT=$${CATALOG_PORT:-10000} ; \
-  CATALOG_READY_PORT_HEX=$$(printf "%%04X" "$$CATALOG_READY_PORT") ; \
-  timeout=60 ; elapsed=0 ; \
-  while [ $$elapsed -lt $$timeout ]; do \
-    if awk -v port="$$CATALOG_READY_PORT_HEX" \
-      '\''NR > 1 { split($$2, addr, ":"); if (toupper(addr[2]) == port && $$4 == "0A") { found=1; exit } } END { exit(found ? 0 : 1) }'\'' \
-      /proc/net/tcp /proc/net/tcp6 2>/dev/null; then \
-      systemd-notify --ready --status="catalog ready (port $$CATALOG_READY_PORT)" ; \
-      break ; \
-    fi ; \
-    sleep 1 ; elapsed=$$((elapsed + 1)) ; \
-  done ; \
-  if [ $$elapsed -ge $$timeout ]; then \
-    systemd-notify --status="catalog failed to become ready before timeout" ; \
-    kill $$APP_PID 2>/dev/null || true ; \
-    wait $$APP_PID 2>/dev/null || true ; \
-    exit 1 ; \
-  fi ; \
-  wait $$APP_PID'
+NotifyAccess=main
+Environment=JAVA_HOME=/opt/zextras/common/lib/jvm/java
+ExecStart=/opt/zextras/common/bin/java \
+  --enable-preview \
+  --enable-native-access=ALL-UNNAMED \
+  -Xms1024m \
+  -jar /usr/share/carbonio/carbonio-catalog/quarkus-run.jar
 User=carbonio-catalog
 Group=carbonio-catalog
 Restart=on-failure

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 
   <dependencies>
     <dependency>
+      <groupId>com.zextras.carbonio</groupId>
+      <artifactId>carbonio-systemd-notify</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>
@@ -162,9 +167,30 @@ SPDX-License-Identifier: AGPL-3.0-only
         <configuration>
           <compilerArgs>
             <arg>-parameters</arg>
+            <arg>--enable-preview</arg>
           </compilerArgs>
           <source>${maven.compiler.release}</source>
           <target>${maven.compiler.release}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <configuration>
+          <argLine>${argLine} --enable-preview --enable-native-access=ALL-UNNAMED</argLine>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <configuration>
+          <argLine>${argLine} --enable-preview --enable-native-access=ALL-UNNAMED</argLine>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/zextras/carbonio/catalog/app/systemd/SystemdReadinessNotifier.java
+++ b/src/main/java/com/zextras/carbonio/catalog/app/systemd/SystemdReadinessNotifier.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.zextras.carbonio.catalog.app.systemd;
+
+import com.zextras.carbonio.systemd.SystemdNotify;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+/**
+ * Signals systemd readiness when the Quarkus HTTP server has fully started.
+ */
+@ApplicationScoped
+public class SystemdReadinessNotifier {
+
+  void onStart(@Observes StartupEvent ev) {
+    SystemdNotify.ready("catalog ready");
+  }
+}


### PR DESCRIPTION
## Summary

Replace the shell wrapper that polled `/proc/net/tcp` to detect readiness with a JVM-level `sd_notify(3)` call using the Foreign Function & Memory API (Java 21 preview), triggered by a Quarkus `StartupEvent` observer.

## Changes

- **`SystemdReadinessNotifier.java`** — new Quarkus startup observer that calls `SystemdNotify.ready()` via the `carbonio-systemd-notify` library
- **`pom.xml`** — add `carbonio-systemd-notify` dependency; configure `--enable-preview` and `--enable-native-access=ALL-UNNAMED` for compiler, surefire, and failsafe (preserving `${argLine}` for JaCoCo)
- **`carbonio-catalog.service`** — invoke Java directly in `ExecStart=` (matching appserver pattern) with `NotifyAccess=main`, removing the shell wrapper indirection
- **`package/carbonio-catalog`** — removed (wrapper script no longer needed)
- **`PKGBUILD`** — remove wrapper script from sources and sha256sums