### PR TITLE
ci: migrate Maven stages to mavenStage()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,6 @@ library(
 
 properties(defaultPipelineProperties())
 
-boolean isBuildingTag() {
-    return env.TAG_NAME ? true : false
-}
-
 pipeline {
     agent {
         node {
@@ -27,7 +23,6 @@ pipeline {
     environment {
         JAVA_OPTS = '-Dfile.encoding=UTF8'
         LC_ALL = 'C.UTF-8'
-        MVN_OPTS = '-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
     }
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
@@ -45,48 +40,19 @@ pipeline {
             }
         }
 
-        stage('Build') {
+        stage('Maven') {
             steps {
-                container('jdk-21') {
-                    sh """
-                        mvn ${MVN_OPTS} -DskipTests clean package
-                        tar czf package/carbonio-catalog-quarkus.tar.gz -C target/ quarkus-app
-                    """
+                script {
+                    mavenStage(
+                        profile         : '',
+                        deployArtifacts : true,
+                        extraTestArgs   : '-Dmaven.test.redirectTestOutputToFile=true',
+                        postBuildScript : 'tar czf package/carbonio-catalog-quarkus.tar.gz -C target/ quarkus-app',
+                    )
                 }
             }
         }
 
-        stage('Tests') {
-            when {
-                expression { params.SKIP_TESTS == false }
-            }
-            steps {
-                container('jdk-21') {
-                    sh "mvn ${MVN_OPTS} -Dmaven.test.redirectTestOutputToFile=true verify"
-                }
-            }
-            post {
-                always {
-                    junit allowEmptyResults: false, testResults: 'target/surefire-reports/*.xml'
-                }
-            }
-        }
-
-        stage('SonarQube analysis') {
-            when {
-                expression { params.SKIP_TESTS == false }
-            }
-            environment {
-                SCANNER_HOME = tool 'SonarScanner'
-            }
-            steps {
-                container('jdk-21') {
-                    withSonarQubeEnv(credentialsId: 'sonarqube-user-token', installationName: 'SonarQube instance') {
-                        sh "mvn ${MVN_OPTS} sonar:sonar"
-                    }
-                }
-            }
-        }
         stage('Publish containers') {
             steps {
                 dockerStage([
@@ -104,22 +70,6 @@ pipeline {
                         ]
                 ])
 
-            }
-        }
-
-        stage('Deploy') {
-            when {
-                anyOf {
-                    branch 'devel'
-                    buildingTag()
-                }
-            }
-            steps {
-                container('jdk-21') {
-                    withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                        sh "mvn ${MVN_OPTS} -s " +  SETTINGS_PATH + ' -DskipTests deploy'
-                    }
-                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,14 +42,12 @@ pipeline {
 
         stage('Maven') {
             steps {
-                script {
-                    mavenStage(
-                        profile         : '',
-                        deployArtifacts : true,
-                        extraTestArgs   : '-Dmaven.test.redirectTestOutputToFile=true',
-                        postBuildScript : 'tar czf package/carbonio-catalog-quarkus.tar.gz -C target/ quarkus-app',
-                    )
-                }
+                mavenStage(
+                    profile         : '',
+                    deployArtifacts : true,
+                    extraTestArgs   : '-Dmaven.test.redirectTestOutputToFile=true',
+                    postBuildScript : 'tar czf package/carbonio-catalog-quarkus.tar.gz -C target/ quarkus-app',
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

Replaces hand-rolled Maven stages (Build, Tests, SonarQube analysis, Deploy) with a single `mavenStage()` call from `jenkins-lib-common@1.5.0`.

### mavenStage() call

```groovy
mavenStage(
    profile         : '',
    deployArtifacts : true,
    extraTestArgs   : '-Dmaven.test.redirectTestOutputToFile=true',
    postBuildScript : 'tar czf package/carbonio-catalog-quarkus.tar.gz -C target/ quarkus-app',
)
```

### Profile decision (case 3)

No Maven profile (`-P ...`) was used anywhere in the old Jenkinsfile, so `profile: ''` is set explicitly to suppress the auto-detect default (`-P dev` / `-P prod`).

| Branch | Old | New |
|--------|-----|-----|
| devel | `mvn ... clean package` (no profile) | `mvn ... clean install -DskipTests` (no profile) |
| tag | `mvn ... clean package` (no profile) | `mvn ... clean install -DskipTests` (no profile) |

### Removed

- `isBuildingTag()` helper function (unused after migration)
- `MVN_OPTS` env var (absorbed by `mavenStage` internal base opts)
- `SKIP_TESTS` pipeline parameter gating (superseded by `mavenStage`)
- Explicit `junit`, `withSonarQubeEnv`, `withCredentials` wrappers

### Behavior changes

- **SonarQube**: previously ran whenever `SKIP_TESTS==false` (all branches). Now gated to `devel` + `PR-*` only — narrowing, expected.
- **Build goal**: `clean package` → `clean install -DskipTests` (`install` is a superset; safe).
- **junit**: `allowEmptyResults: false` → `allowEmptyResults: true` (minor, `mavenStage` default).
- **JaCoCo coverage**: auto-detected from effective POM; stage added if plugin present.
- **Deploy**: same gating (devel + tags).

### Unchanged

- All non-Maven stages: `Publish containers`, `Build deb/rpm`, `Upload artifacts`, `Bump version`
- `package/carbonio-catalog-quarkus.tar.gz` produced via `postBuildScript` (same path, same content)

### Test plan

1. Push to feature branch → verify stages: Maven Build, Maven Test, Maven Coverage (skipped if no JaCoCo), SonarQube Analysis (skipped), Maven Deploy (skipped)
2. Verify `junit` UI populated
3. Verify `dockerStage` still finds `target/quarkus-app` (via `postBuildScript` tar)
4. Open PR → verify SonarQube runs on `PR-*`
5. Merge to devel → verify deploy runs
6. Cut tag → verify deploy runs
