### PR TITLE
chore: update carbonio-sidecar base image from latest to devel

### DIFF
--- a/Dockerfile-sidecar
+++ b/Dockerfile-sidecar
@@ -1,4 +1,4 @@
-FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:devel
 
 # Service registration
 COPY package/carbonio-catalog.hcl /consul/config/


### PR DESCRIPTION
## Summary
- Update the sidecar base image tag from `carbonio-sidecar:latest` to `carbonio-sidecar:devel` in the sidecar Dockerfile(s).

## Test plan
- [ ] CI build of the sidecar image(s) succeeds
- [ ] Sidecar container starts and registers with consul as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)