### PR TITLE
chore(pom): [IN-1083] update testcontainers version to 2.0.3 and quarkus to 3.33.1 LTS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
             steps {
                 mavenStage(
                     profile         : '',
-                    deployArtifacts : true,
+                    deployArtifacts : false,
                     extraTestArgs   : '-Dmaven.test.redirectTestOutputToFile=true',
                     postBuildScript : 'tar czf package/carbonio-catalog-quarkus.tar.gz -C target/ quarkus-app',
                 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@1.5.0',
+    identifier: 'jenkins-lib-common@1.7.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@1.6.2',
+    identifier: 'jenkins-lib-common@1.5.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,6 @@ SPDX-License-Identifier: AGPL-3.0-only
           <argLine>${argLine} --enable-preview --enable-native-access=ALL-UNNAMED</argLine>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-            <api.version>1.44</api.version>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -190,7 +189,6 @@ SPDX-License-Identifier: AGPL-3.0-only
           <argLine>${argLine} --enable-preview --enable-native-access=ALL-UNNAMED</argLine>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-            <api.version>1.44</api.version>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -353,7 +351,7 @@ SPDX-License-Identifier: AGPL-3.0-only
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.3</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -363,16 +361,6 @@ SPDX-License-Identifier: AGPL-3.0-only
         <version>${quarkus.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.github.docker-java</groupId>
-        <artifactId>docker-java-api</artifactId>
-        <version>3.7.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.github.docker-java</groupId>
-        <artifactId>docker-java-transport-zerodep</artifactId>
-        <version>3.7.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>consul</artifactId>
-      <version>1.19.8</version>
+      <version>1.21.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.platform.version>3.30.6</quarkus.platform.version>
+    <quarkus.platform.version>3.33.1</quarkus.platform.version>
     <surefire-plugin.version>3.4.0</surefire-plugin.version>
     <skip.open-api.schema.generation>false</skip.open-api.schema.generation>
   </properties>
@@ -179,6 +179,7 @@ SPDX-License-Identifier: AGPL-3.0-only
           <argLine>${argLine} --enable-preview --enable-native-access=ALL-UNNAMED</argLine>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <api.version>1.44</api.version>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -189,6 +190,7 @@ SPDX-License-Identifier: AGPL-3.0-only
           <argLine>${argLine} --enable-preview --enable-native-access=ALL-UNNAMED</argLine>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+            <api.version>1.44</api.version>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -252,11 +254,6 @@ SPDX-License-Identifier: AGPL-3.0-only
       <id>default</id>
       <name>Maven public</name>
       <url>https://repo.maven.apache.org/maven2/</url>
-    </repository>
-    <repository>
-      <id>java-net</id>
-      <name>Maven Java.net</name>
-      <url>https://maven.java.net/content/repositories/staging</url>
     </repository>
     <repository>
       <releases>

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>consul</artifactId>
-      <version>1.21.3</version>
+      <artifactId>testcontainers-consul</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -355,11 +354,28 @@ SPDX-License-Identifier: AGPL-3.0-only
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>2.0.5</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>io.quarkus.platform</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${quarkus.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-api</artifactId>
+        <version>3.7.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.docker-java</groupId>
+        <artifactId>docker-java-transport-zerodep</artifactId>
+        <version>3.7.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/resources/open-api.yaml
+++ b/src/main/resources/open-api.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 ---
 openapi: 3.0.3
 info:

--- a/src/main/resources/open-api.yaml
+++ b/src/main/resources/open-api.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
-#
-# SPDX-License-Identifier: AGPL-3.0-only
-
 ---
 openapi: 3.0.3
 info:


### PR DESCRIPTION
- least compatible with docker 29+
- does not need to define docker api.version (testcontainers 1.21+ needs api.version=1.44 to work with docker 29+)
- upgraded jenkins-lib-common to 1.7.0 (1.6.2 calls a docker info which times out)

Read the AI generated comment, because the compatibility matrix is quite hard to understand