### PR TITLE
feat(packaging): use arch=('any') for architecture-independent package

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -10,7 +10,7 @@ copyright=(
   "2023-2024, Zextras <https://www.zextras.com>"
 )
 license=("AGPL-3.0-only")
-arch=('x86_64')
+arch=('any')
 section="admin"
 priority="optional"
 url="https://www.zextras.com/"


### PR DESCRIPTION
## Summary

- Replace `arch=('x86_64')` with `arch=('any')` in PKGBUILD since this package does not contain architecture-specific binaries

IN-951