### PR TITLE
chore(deps): update jenkins-lib-common to v2.8.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@1.7.5',
+    identifier: 'jenkins-lib-common@v2.8.6',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,9 +89,7 @@ pipeline {
                 jfrog 'jfrog-cli'
             }
             steps {
-                uploadStage(
-                    packages: yapHelper.resolvePackageNames()
-                )
+                uploadStage()
             }
         }
         stage('Bump version') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v2.8.6',
+    identifier: 'jenkins-lib-common@v2.8.7',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
## Description

Upgrade `jenkins-lib-common` from `1.7.5` to `v2.8.7`.

### Changes applied

- Updated library version reference to `v2.8.7`
- Migrated `uploadStage(packages: ...)` to the new API
  (packages parameter was removed in v2.8.0 — the library now resolves
  package metadata internally from PKGBUILD files)

### Breaking changes in this upgrade

| Version | Change | Action Taken |
|---------|--------|--------------|
| v2.0.0 | Trunk-based branch guards replace `devel*`/`release*` | N/A — no redundant branch guards were present in the pipeline |
| v2.8.0 | `uploadStage(packages:)` removed, hard-errors at runtime | Removed packages arg (`yapHelper.resolvePackageNames()` call eliminated) |

### Verification

- [x] Jenkinsfile syntax is valid
- [x] No `packages:` arg in `uploadStage()` calls
- [x] No orphaned `yapHelper.resolvePackageNames()` calls
- [x] PR build passes

## Type of change

- [x] Chore / CI (`chore:` / `ci:` / `test:` → no release)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Branch is rebased on latest default branch with a linear history

## Notes for reviewers

Automated lib-common upgrade. The Renovate-generated PR was at `v2.8.6` — bumped to `v2.8.7` and the breaking `packages:` parameter migration applied on top. Please verify the Upload stage runs correctly on the PR build.