### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+# Prep stage runs on BUILDPLATFORM (amd64 CI builder) — no QEMU. Creates the
+# arch-independent service-discover dir/token so the final image needs no RUN.
+FROM --platform=$BUILDPLATFORM busybox AS prep
+RUN mkdir -p /staging/etc/carbonio/catalog/service-discover/ \
+    && touch /staging/etc/carbonio/catalog/service-discover/token
+
 FROM eclipse-temurin:21-jdk
 
 WORKDIR /app
@@ -9,8 +15,7 @@ ENV CATALOG_HOST=0.0.0.0
 ENV CATALOG_PORT=10000
 ENV CONSUL_URL=http://consul:8500
 ENV CONSUL_TOKEN_PATH=/etc/carbonio/catalog/service-discover/token
-RUN mkdir -p /etc/carbonio/catalog/service-discover/ \
-    && touch /etc/carbonio/catalog/service-discover/token
+COPY --from=prep /staging/etc /etc
 
 ENV JDK_JAVA_OPTIONS="-Xms256m -Xmx512m"
 

--- a/Dockerfile-sidecar
+++ b/Dockerfile-sidecar
@@ -9,8 +9,7 @@ COPY package/carbonio-catalog-intentions.json       /etc/carbonio/catalog/servic
 COPY package/carbonio-catalog-policies.json         /etc/carbonio/catalog/service-discover/policies.json
 
 # Setup script
-COPY package/carbonio-catalog-setup /usr/local/bin/carbonio-catalog-setup
-RUN chmod +x /usr/local/bin/carbonio-catalog-setup
+COPY --chmod=755 package/carbonio-catalog-setup /usr/local/bin/carbonio-catalog-setup
 
 ENV SERVICE_NAME=carbonio-catalog
 ENV SETUP_SCRIPT="carbonio-catalog-setup setup"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,7 @@ pipeline {
                 dockerStage([
                         dockerfile: 'Dockerfile',
                         imageName : 'carbonio-catalog',
+                        platforms: ['linux/amd64', 'linux/arm64'] as Set,
                         ocLabels  : [
                                 title          : 'Carbonio Catalog Service'
                         ]
@@ -61,6 +62,7 @@ pipeline {
                 dockerStage([
                         dockerfile: 'Dockerfile-sidecar',
                         imageName : 'carbonio-catalog-sidecar',
+                        platforms: ['linux/amd64', 'linux/arm64'] as Set,
                         ocLabels  : [
                                 title : 'Carbonio Catalog Service Sidecar',
                         ]


### PR DESCRIPTION
Adds `platforms: ['linux/amd64', 'linux/arm64'] as Set` to each `dockerStage` call so images build for arm64 (Apple Silicon / MacOS) in addition to amd64.

Mirrors the merged carbonio-mailbox pattern (PR #994). The `as Set` cast is required: dockerHelper only emits `--platform` when platforms is a Set.

Ref: IN-951