### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@2.10.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Prep stage runs on BUILDPLATFORM (amd64 CI builder) — no QEMU. Creates the
 # arch-independent service-discover dir/token so the final image needs no RUN.
-FROM --platform=$BUILDPLATFORM busybox AS prep
+FROM --platform=$BUILDPLATFORM docker.io/library/busybox AS prep
 RUN mkdir -p /staging/etc/carbonio/catalog/service-discover/ \
     && touch /staging/etc/carbonio/catalog/service-discover/token
 
-FROM eclipse-temurin:21-jdk
+FROM docker.io/library/eclipse-temurin:21-jdk
 
 WORKDIR /app
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v2.8.7',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
## Buildah migration

Replacing `docker buildx` with **buildah**, which requires fully-qualified image references.

### Changes
- **Dockerfiles:** fully-qualify base images (e.g. `alpine:3` -> `docker.io/library/alpine:3`). Multi-stage aliases and already-qualified refs untouched.
- **Jenkinsfile:** bump `jenkins-lib-common` to `@2.10.0`.

> Draft - part of org-wide buildah migration.