### PR TITLE
chore(deps)!: migrate to jenkins-lib-common v4.1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v2.10.0',
+    identifier: 'jenkins-lib-common@v4.1.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',
@@ -41,9 +41,6 @@ pipeline {
         stage('Maven') {
             steps {
                 mavenStage(
-                    profile         : '',
-                    deployArtifacts : false,
-                    extraTestArgs   : '-Dmaven.test.redirectTestOutputToFile=true',
                     postBuildScript : 'tar czf package/carbonio-catalog-quarkus.tar.gz -C target/ quarkus-app',
                 )
             }

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
     <quarkus.platform.version>3.33.1</quarkus.platform.version>
     <surefire-plugin.version>3.4.0</surefire-plugin.version>
     <skip.open-api.schema.generation>false</skip.open-api.schema.generation>
+    <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
IN-1168 — migrate `carbonio-catalog-service` from `jenkins-lib-common@v2.10.0` to `v4.1.4` so
package builds mirror to Nexus for the QA handover.

This repo is already at `v2.10.0`, so the trunk-based branch guard (`cd7c38c`, v2.0.0) and the
DinD→Buildah switch (`9b02055`, v2.10.0) were already in effect — no change needed there
(container publishing already goes through `dockerStage`, no raw `docker`/`withDockerRegistry`
calls). `gitleaksStage()` is not used in this pipeline, so the v3.0.0 gitleaks-in-pod change is
not applicable either.

The `mavenStage(...)` parameter purge in v4.0.0 (`746919c`) does apply:

- Removed `profile: ''` — was already a no-op (empty string activates no Maven profile); nothing
  to migrate.
- Removed `deployArtifacts: false` — deploy is now automatically branch/tag-gated instead of an
  opt-in flag. Previously this repo explicitly opted **out** of `mvn deploy`; under v4.x, Maven
  Deploy will now run on the default branch (`devel`) and tags. This is an intended consequence of
  the migration goal (packages mirroring to Nexus) and is called out here as a genuine behaviour
  change, not a bug.
- Removed `extraTestArgs: '-Dmaven.test.redirectTestOutputToFile=true'` — moved into `pom.xml`
  `<properties>` as `<maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>`.
  Verified against `pom.xml`: `maven-surefire-plugin` and `maven-failsafe-plugin` both resolve
  `redirectTestOutputToFile` from the user property `maven.test.redirectTestOutputToFile` by
  default (no explicit override in this POM's plugin `<configuration>`), so setting the property
  reproduces the exact same effect for both `mvn verify`'s test and integration-test phases.
- `postBuildScript` (still supported) kept verbatim.

Ref: https://zextras.atlassian.net/browse/IN-1168
